### PR TITLE
Local munki server workflow scripts

### DIFF
--- a/revert_changes.sh
+++ b/revert_changes.sh
@@ -5,11 +5,11 @@
 
 #   functions   #
 function revert_munki_repo_preferences (){
-    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev &> /dev/null
+    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev
 }
 
 #   script   #
-revert_munki_repo_preferences 
+revert_munki_repo_preferences &> /dev/null
 
 
 #   testing   #

--- a/revert_changes.sh
+++ b/revert_changes.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh --no--rcs
+
+# Script reverts the changes of munki repository preference made for the local munki server workflow
+
+
+#   functions   #
+function revert_munki_repo_preferences (){
+    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev &> /dev/null
+}
+
+#   script   #
+revert_munki_repo_preferences 
+
+
+#   testing   #
+echo "Script revert_changes complete."

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -1,19 +1,164 @@
 #!/bin/zsh --no-rcs
 
+#creates a folder structure; connects to the dev repo; clones a VM from template and starts it
 
-# Create folder structure
-SERVER_ROOT=/Users/Shared/munki_repo
 
-mkdir $SERVER_ROOT
-mkdir $SERVER_ROOT/catalogs
-mkdir $SERVER_ROOT/icons
-mkdir $SERVER_ROOT/manifests
-mkdir $SERVER_ROOT/pkgs
-mkdir $SERVER_ROOT/pkgsinfo
+#   Set up template   #
+#New UTM VM with name according to variable
+#Press command k in finder window and connect to: dav.its-cs-munki-test-01.its.unibas.ch/files/
+#Press "New Shared Directory" in UTM and choose: dav.its-cs-munki-test-01.its.unibas.ch/files/html/munki_repo_dev
+#Start VM
+    #Set language according to variable
+    #Set username and password according to variable
+    #Activate screen sharing permission at: System Settings > General > Sharing > Screen Sharing
 
-chmod -R a+rX $SERVER_ROOT
+    ### ### ###
+    #Open search machine and enroll JAMF with following link: https://its-mcs-dm.its.unibas.ch:8443/enroll/
+        #Wait until completion & follow instructions if needed (also review the MDM Profile in System Settings > Profiles)
+    ### ### ###
 
-sudo ln -s $SERVER_ROOT /Library/WebServer/Documents/
+#Restart VM and follow instructions if needed
+#Copy the serial number (to create a Manifest in MunkiAdmin)
 
-sudo apachectl start
+#You should be able to run this script as long as UTM is installed.
 
+
+#   variables   #
+NAME="template"
+USER=$NAME
+PASSWORD=$NAME
+LANGUAGE="en"                                                       #different hostname pattern for different languages!
+CLONE_SUFFIX="clone"
+    SUFFIX=$CLONE_SUFFIX
+HOSTNAME="${NAME}s-Virtual-Machine.local"                           #for ${LANGUAGE}=="en"
+
+
+#   functions   #
+function create_folder_structure (){
+    SERVER_ROOT=/Users/Shared/munki_repo
+
+    mkdir $SERVER_ROOT
+    mkdir $SERVER_ROOT/catalogs
+    mkdir $SERVER_ROOT/icons
+    mkdir $SERVER_ROOT/manifests
+    mkdir $SERVER_ROOT/pkgs
+    mkdir $SERVER_ROOT/pkgsinfo
+
+    chmod -R a+rX $SERVER_ROOT
+
+    sudo ln -s $SERVER_ROOT /Library/WebServer/Documents/
+}
+
+function start_apachectl (){
+    launchctl print system/org.apache.httpd &> /dev/null
+
+    if [ $? -eq 0 ]; then
+        sleep .2
+    else 
+        sudo apachectl start
+    fi
+}
+
+function change_munki_repo_preferences (){
+    #if #server active; then                                            #funktion nur ausführen wenn der server aktiv ist?
+        MUNKI_PROD="files/html/munki_repo_prod"                         #abhängig von filestruktur des lokalen Servers? 
+        /usr/local/bin/autopkg run --key MUNKI_REPO=“/Volumes/MUNKI_PROD“   
+        #defaults write com.github.autopkg MUNKI_REPO /Volumes/files/html/munki_repo_dev
+    #fi
+}
+
+function changeto_munki_dev_repo (){ 
+    sudo defaults write \
+    /Library/Preferences/ManagedInstalls.plist \
+    ManifestURL \
+    "https://its-cs-munki-test-01.its.unibas.ch/munki_repo_dev/manifests/ITS" \
+    && \
+    sudo defaults write \
+    /Library/Preferences/ManagedInstalls.plist \
+    SoftwareRepoURL \
+    "https://its-cs-munki-test-01.its.unibas.ch/munki_repo_dev"
+}
+
+function update_repo (){
+    autopkg repo-update all
+    sleep .5
+}
+
+function activate_utmctl (){ 
+    #/Applications/UTM.app/Contents/MacOS/utmctl
+    sudo ln -sf /Applications/UTM.app/Contents/MacOS/utmctl /usr/local/bin/utmctl
+}
+
+function open_utm(){
+    if ps -A | grep -v grep | grep -iq 'utm.app'; then              #check if utm is on
+        sleep .2
+    else 
+        open /Applications/UTM.app/
+        sleep .5
+    fi
+}
+
+function stop_templateVM (){
+    if [[ $(utmctl status $NAME)=="started" ]]; then                #checks if template is running
+        utmctl stop $NAME
+        sleep .2
+    fi
+}
+
+function delete_VMcopy (){
+    if [[ $(utmctl status ${NAME}_${SUFFIX})=="started" ]]; then    #checks if copy is running  
+        utmctl stop ${NAME}_${SUFFIX}
+        sleep .5
+    fi
+
+    utmctl delete ${NAME}_${SUFFIX}
+}
+
+function check_delete_existing_VMcopy (){  
+    while ( utmctl list | grep ${NAME}_${SUFFIX} ); do              #checks if copy already exists
+        if [ $? -eq 0 ]; then
+            delete_VMcopy
+        fi
+    done
+}
+
+function clone_templateVM (){
+    utmctl clone $NAME --name ${NAME}_${SUFFIX} 
+    sleep .2
+}
+
+function launch_VMcopy (){
+    utmctl start ${NAME}_${SUFFIX}
+    sleep .25
+}
+
+function share_screen (){
+    open vnc://${USER}:${PASSWORD}@$HOSTNAME                        # vnc://[user]:[password]@[server]:[port]
+}
+
+function revert_munki_repo_preferences (){
+    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev
+}
+
+#   script   #
+#create_folder_structure 2> /dev/null
+#start_apachectl
+#change_munki_repo_preferences                                      #manuell?
+#changeto_munki_dev_repo
+#update_repo > /dev/null
+#activate_utmctl
+open_utm
+stop_templateVM &> /dev/null
+#delete_VMcopy                                                      #läuft in check_delete_existing_VMcopy
+check_delete_existing_VMcopy &> /dev/null
+clone_templateVM
+launch_VMcopy
+share_screen                                                        # -> bug wenn JAMF enrollt ist -> manuelles munki enrollment
+#revert_munki_repo_preferences                                      # setzt die munki änderungen zurück (separates skript?)
+
+#   testing   #
+#echo "Hostname: $HOSTNAME"
+#echo "Name: $NAME"
+#echo "Username: $USER"
+#echo "Password: $PASSWORD"
+echo "Script completed."

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -18,14 +18,15 @@
 NAME="template"
 USER=$NAME
 PASSWORD=$NAME
-LANGUAGE="en"                                                       #different hostname pattern for different languages!
+LANGUAGE="en"                                                                   # different hostname pattern for different languages!
 CLONE_SUFFIX="clone"
     SUFFIX=$CLONE_SUFFIX
-HOSTNAME="${NAME}s-Virtual-Machine.local"                           #for ${LANGUAGE}=="en"
+HOSTNAME="${NAME}s-Virtual-Machine.local"                                       # for ${LANGUAGE}=="en"
+SERVER_ROOT=/Users/Shared/munki_repo
 
 
 #   functions   #
-function start_apachectl (){
+function start_apachectl (){                                                    # starts apachectl server
     launchctl print system/org.apache.httpd &> /dev/null
 
     if [ $? -eq 0 ]; then
@@ -35,7 +36,7 @@ function start_apachectl (){
     fi
 }
 
-function changeto_munki_dev_repo (){ 
+function changeto_munki_dev_repo (){                                            # switches to development repository
     sudo defaults write \
     /Library/Preferences/ManagedInstalls.plist \
     ManifestURL \
@@ -50,19 +51,19 @@ function changeto_munki_dev_repo (){
 function change_munki_repo_preferences (){
         launchctl print system/org.apache.httpd &> /dev/null
 
-    if [ $? -eq 0 ]; then                                                       #checks if server is running
-        /usr/local/bin/autopkg run --key MUNKI_REPO=$SERVER_ROOT &> /dev/null   #?
+    if [ $? -eq 0 ]; then                                                       # checks if server is running
+        /usr/local/bin/autopkg run --key MUNKI_REPO=$SERVER_ROOT &> /dev/null
         #defaults write com.github.autopkg MUNKI_REPO /Volumes/files/html/munki_repo_dev
     fi
 }
 
-function update_repo (){
+function update_repo (){                                                        # updates repositories
     autopkg repo-update all
     sleep .5
 }
 
 function open_utm(){
-    if ps -A | grep -v grep | grep -iq 'utm.app'; then              #check if utm is on
+    if ps -A | grep -v grep | grep -iq 'utm.app'; then                          # check if utm is on
         sleep .2
     else 
         open /Applications/UTM.app/
@@ -71,14 +72,14 @@ function open_utm(){
 }
 
 function stop_templateVM (){
-    if [[ $(utmctl status $NAME)=="started" ]]; then                #checks if template is running
+    if [[ $(utmctl status $NAME)=="started" ]]; then                            # checks if template is running
         utmctl stop $NAME
         sleep .2
     fi
 }
 
 function delete_VMcopy (){
-    if [[ $(utmctl status ${NAME}_${SUFFIX})=="started" ]]; then    #checks if copy is running  
+    if [[ $(utmctl status ${NAME}_${SUFFIX})=="started" ]]; then                # checks if copy is running  
         utmctl stop ${NAME}_${SUFFIX}
         sleep .5
     fi
@@ -87,29 +88,25 @@ function delete_VMcopy (){
 }
 
 function check_delete_existing_VMcopy (){  
-    while ( utmctl list | grep ${NAME}_${SUFFIX} ); do              #checks if copy already exists
+    while ( utmctl list | grep ${NAME}_${SUFFIX} ); do                          # checks if copy already exists
         if [ $? -eq 0 ]; then
             delete_VMcopy
         fi
     done
 }
 
-function clone_templateVM (){
+function clone_templateVM (){                                                   # clones template
     utmctl clone $NAME --name ${NAME}_${SUFFIX} 
     sleep .2
 }
 
-function launch_VMcopy (){
+function launch_VMcopy (){                                                      # launches copy
     utmctl start ${NAME}_${SUFFIX}
     sleep .25
 }
 
-function share_screen (){
-    open vnc://${USER}:${PASSWORD}@$HOSTNAME                        # vnc://[user]:[password]@[server]:[port]
-}
-
-function revert_munki_repo_preferences (){
-    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev &> /dev/null
+function share_screen (){                                                       # starts screen sharing
+    open vnc://${USER}:${PASSWORD}@$HOSTNAME                                    # (vnc://[user]:[password]@[server]:[port])
 }
 
 
@@ -117,14 +114,14 @@ function revert_munki_repo_preferences (){
 start_apachectl                                   
 changeto_munki_dev_repo
 change_munki_repo_preferences 
-update_repo > /dev/null
+update_repo &> /dev/null
 open_utm
 stop_templateVM &> /dev/null
-###delete_VMcopy &> /dev/null                                                  #läuft in check_delete_existing_VMcopy
+###delete_VMcopy &> /dev/null                                                   # runs in check_delete_existing_VMcopy
 check_delete_existing_VMcopy &> /dev/null
 clone_templateVM 
 launch_VMcopy
-share_screen                                                                    # -> bug wenn JAMF enrollt ist -> manuelles munki enrollment
+share_screen                                                                    # bug wenn JAMF enrollt ist -> manuelles munki enrollment
 
 
 #   testing   #

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -62,11 +62,11 @@ function start_apachectl (){
 function change_munki_repo_preferences (){
     launchctl print system/org.apache.httpd &> /dev/null
 
-    if [ $? -eq 0 ]; then                                               #funktion nur ausführen wenn der server aktiv ist
-        /usr/local/bin/autopkg run --key MUNKI_REPO=$SERVER_ROOT        #?
+    if [ $? -eq 0 ]; then                                                       #funktion nur ausführen wenn der server aktiv ist
+        /usr/local/bin/autopkg run --key MUNKI_REPO=$SERVER_ROOT &> /dev/null   #?
         #defaults write com.github.autopkg MUNKI_REPO /Volumes/files/html/munki_repo_dev
     else
-        /usr/local/bin/autopkg run --key MUNKI_REPO="/Volumes/files/html/munki_repo_dev"
+        /usr/local/bin/autopkg run --key MUNKI_REPO="/Volumes/files/html/munki_repo_dev" &> /dev/null
     fi 
 }
 
@@ -140,24 +140,24 @@ function share_screen (){
 }
 
 function revert_munki_repo_preferences (){
-    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev
+    defaults write com.github.autopkg MUNKI_REPO /volumes/files/html/munki_repo_dev &> /dev/null
 }
 
 #   script   #
 #create_folder_structure 2> /dev/null
-#start_apachectl
-#change_munki_repo_preferences                                      #manuell?
-#changeto_munki_dev_repo
+start_apachectl
+change_munki_repo_preferences                                      #manuell?
+changeto_munki_dev_repo
 #update_repo > /dev/null
 #activate_utmctl
 open_utm
 stop_templateVM &> /dev/null
-#delete_VMcopy                                                      #läuft in check_delete_existing_VMcopy
+###delete_VMcopy &> /dev/null                                                  #läuft in check_delete_existing_VMcopy
 check_delete_existing_VMcopy &> /dev/null
-clone_templateVM
+clone_templateVM 
 launch_VMcopy
-share_screen                                                        # -> bug wenn JAMF enrollt ist -> manuelles munki enrollment
-#revert_munki_repo_preferences                                      # setzt die munki änderungen zurück (separates skript?)
+#share_screen                                                        # -> bug wenn JAMF enrollt ist -> manuelles munki enrollment
+revert_munki_repo_preferences                                      # setzt die munki änderungen zurück (separates skript?)
 
 #   testing   #
 #echo "Hostname: $HOSTNAME"

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -60,11 +60,14 @@ function start_apachectl (){
 }
 
 function change_munki_repo_preferences (){
-    #if #server active; then                                            #funktion nur ausführen wenn der server aktiv ist?
-        MUNKI_PROD="files/html/munki_repo_prod"                         #abhängig von filestruktur des lokalen Servers? 
-        /usr/local/bin/autopkg run --key MUNKI_REPO=“/Volumes/MUNKI_PROD“   
+    launchctl print system/org.apache.httpd &> /dev/null
+
+    if [ $? -eq 0 ]; then                                               #funktion nur ausführen wenn der server aktiv ist
+        /usr/local/bin/autopkg run --key MUNKI_REPO=$SERVER_ROOT        #?
         #defaults write com.github.autopkg MUNKI_REPO /Volumes/files/html/munki_repo_dev
-    #fi
+    else
+        /usr/local/bin/autopkg run --key MUNKI_REPO="/Volumes/files/html/munki_repo_dev"
+    fi 
 }
 
 function changeto_munki_dev_repo (){ 

--- a/start_setup.sh
+++ b/start_setup.sh
@@ -2,6 +2,7 @@
 
 # Script creates folder structure and activates utmctl
 # Runs once
+# UTM has to be installed
 
 #   functions   #
 function create_folder_structure (){
@@ -20,13 +21,13 @@ function create_folder_structure (){
 }
 
 function activate_utmctl (){ 
-    #/Applications/UTM.app/Contents/MacOS/utmctl
+    #/Applications/UTM.app/Contents/MacOS/utmctl &> /dev/null
     sudo ln -sf /Applications/UTM.app/Contents/MacOS/utmctl /usr/local/bin/utmctl
 }
 
 
 #   script   #
-create_folder_structure 2> /dev/null
+create_folder_structure &> /dev/null
 activate_utmctl
 
 

--- a/start_setup.sh
+++ b/start_setup.sh
@@ -1,0 +1,34 @@
+#!/bin/zsh --no-rcs
+
+# Script creates folder structure and activates utmctl
+# Runs once
+
+#   functions   #
+function create_folder_structure (){
+    SERVER_ROOT=/Users/Shared/munki_repo
+
+    mkdir $SERVER_ROOT
+    mkdir $SERVER_ROOT/catalogs
+    mkdir $SERVER_ROOT/icons
+    mkdir $SERVER_ROOT/manifests
+    mkdir $SERVER_ROOT/pkgs
+    mkdir $SERVER_ROOT/pkgsinfo
+
+    chmod -R a+rX $SERVER_ROOT
+
+    sudo ln -s $SERVER_ROOT /Library/WebServer/Documents/
+}
+
+function activate_utmctl (){ 
+    #/Applications/UTM.app/Contents/MacOS/utmctl
+    sudo ln -sf /Applications/UTM.app/Contents/MacOS/utmctl /usr/local/bin/utmctl
+}
+
+
+#   script   #
+create_folder_structure 2> /dev/null
+activate_utmctl
+
+
+#   testing   #
+echo "Script setup_structure complete."

--- a/start_setup.sh
+++ b/start_setup.sh
@@ -4,6 +4,7 @@
 # Runs once
 # UTM has to be installed
 
+
 #   functions   #
 function create_folder_structure (){
     SERVER_ROOT=/Users/Shared/munki_repo


### PR DESCRIPTION
start_setup.sh (einmalig)
- filestruktur
- utmctl

setup_server.sh 
- startet apachectl
- ändert munki repo & repo preference
- startet Kopie einer vorbereiteten VM (mit shared directory & screen sharing permission)
- startet screen sharing

revert_changes.sh
- ändert die repo preference wieder zurück